### PR TITLE
Avoid calling RMclear on RISC OS 3.5 or higher

### DIFF
--- a/folder/!Run,feb
+++ b/folder/!Run,feb
@@ -1,6 +1,6 @@
 Set Demo$Dir <Obey$Dir>
 |
-RMclear
+RMEnsure UtilityModule 3.50 RMclear
 RMLoad <Demo$Dir>.MemAlloc 
 SCREENSIZE 120K
 |RMASIZE 24K 


### PR DESCRIPTION
Calling RMclear on newer machines tends to have negative consequences - for example, when testing with the RiscPC, calling RMclear resulted in the TaskManager module being killed.